### PR TITLE
Show which compareMode is unsupported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,7 @@ function computeDepDetails(FS, options, depPath, callback) {
       break;
     }
     default:
-      throw new Error('unsupported compareMode');
+      throw new Error(`unsupported compareMode "${compareMode}".`);
   }
 }
 


### PR DESCRIPTION
> Error: unsupported compareMode "mtime # invalidate cache based on file's mtime (local development)"

=)

\+ I want to talk to you about updating the NPM package and moving it to the org if possible so please remind me in case I forget.